### PR TITLE
X9076: jdi-1440p: Set v-back-porch to 10

### DIFF
--- a/arch/arm/boot/dts/msm8974-oppo/dsi-panel-jdi-1440p-video.dtsi
+++ b/arch/arm/boot/dts/msm8974-oppo/dsi-panel-jdi-1440p-video.dtsi
@@ -31,7 +31,7 @@
 		qcom,mdss-dsi-h-back-porch = <34>;
 		qcom,mdss-dsi-h-pulse-width = <14>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
-		qcom,mdss-dsi-v-back-porch = <6>;
+		qcom,mdss-dsi-v-back-porch = <10>;
 		qcom,mdss-dsi-v-front-porch = <4>;
 		qcom,mdss-dsi-v-pulse-width = <1>;
 		qcom,mdss-dsi-h-left-border = <0>;
@@ -210,7 +210,7 @@
 		qcom,mdss-dsi-h-back-porch = <34>;
 		qcom,mdss-dsi-h-pulse-width = <14>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
-		qcom,mdss-dsi-v-back-porch = <6>;
+		qcom,mdss-dsi-v-back-porch = <10>;
 		qcom,mdss-dsi-v-front-porch = <4>;
 		qcom,mdss-dsi-v-pulse-width = <1>;
 		qcom,mdss-dsi-h-left-border = <0>;


### PR DESCRIPTION
- From oppo 4.4 kernel source drop

Change-Id: Iaf0b450589ec09537103973edecd0471f097f7d2
