### PR TITLE
msm: mdss: reduce vsync waiting time only when it is enabled

### DIFF
--- a/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
+++ b/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
@@ -832,7 +832,7 @@ static void mdss_mdp_cmd_stop_sub(struct mdss_mdp_ctl *ctl,
 		 * next vsync if there has no kickoff pending
 		 */
 		ctx->rdptr_enabled = 1;
-		if (sctx)
+		if (sctx && sctx->rdptr_enabled)
 			sctx->rdptr_enabled = 1;
 	}
 	spin_unlock_irqrestore(&ctx->clk_lock, flags);


### PR DESCRIPTION
Reduce vsync waiting time only when vsync is still enabled.
Otherwise, it will trigger waiting for next vsync mistakenly
and timeout eventually.

CRs-Fixed: 762791
Change-Id: Ic3df12a4b449fa6d6cbbd1169e890b0cf3f67db1
Signed-off-by: Kuogee Hsieh khsieh@codeaurora.org
